### PR TITLE
Aggiunto codice "OO"

### DIFF
--- a/Spesometro/Tabelle/IdPaese.cs
+++ b/Spesometro/Tabelle/IdPaese.cs
@@ -256,6 +256,7 @@
                     new IdPaese { Nome = "Yemen", Codice = "YE" },
                     new IdPaese { Nome = "Zambia", Codice = "ZM" },
                     new IdPaese { Nome = "Zimbabwe", Codice = "ZW" },
+                    new IdPaese { Nome = "Bollette doganali", Codice = "OO" }, //RISOLUZIONE N. 87/E AdE del 05/07/2017
                 };
             } 
         }


### PR DESCRIPTION
Come da RISOLUZIONE N. 87/E AdE del 05/07/2017:
"Al fine di non creare aggravi per i contribuenti che dispongono di software contabili che, ad oggi, hanno le limitazioni specificate nel quesito e nelle more di un loro rapido adattamento, si consente – solo con riferimento alle comunicazioni del periodo d’imposta 2017 – di valorizzare, all’interno della sezione <CedentePrestatoreDTR>, l’elemento informativo <IdFiscaleIVA>\<IdPaese> con la stringa “OO” e l’elemento <IdFiscaleIVA>\<IdCodice> con una sequenza di undici “9”.